### PR TITLE
feat: enhance test failure message readability

### DIFF
--- a/test/ArraySum.js
+++ b/test/ArraySum.js
@@ -56,9 +56,7 @@ describe("ArraySum", async function () {
 
             logGasUsage(gasEstimate);
 
-            expect(gasEstimate).to.satisfy(function (val) {
-                return val <= TARGET_GAS_PRICE;
-            });
+            expect(gasEstimate).lte(TARGET_GAS_PRICE);
         });
     });
 

--- a/test/Distribute.js
+++ b/test/Distribute.js
@@ -72,9 +72,7 @@ describe("Distribute", async function () {
 
             logGasUsage(gasEstimate);
 
-            expect(gasEstimate).to.satisfy(function (val) {
-                return val <= TARGET_GAS_PRICE;
-            });
+            expect(gasEstimate).lte(TARGET_GAS_PRICE);
         });
     });
 


### PR DESCRIPTION
Use of `chai` `lte` (less-than-or-equal) function instead of `satisfy` to leverage the built-in expect error logging:

Before:
 
<img width="921" alt="Screen Shot 2022-10-19 at 11 19 45 PM" src="https://user-images.githubusercontent.com/43687739/196785157-8dd2de4b-9469-45aa-b577-46b24e16d0e3.png">


After:
<img width="955" alt="Screen Shot 2022-10-19 at 11 19 21 PM" src="https://user-images.githubusercontent.com/43687739/196785178-74d50ea0-8f5f-4e2c-b6cd-f9156d6d5782.png">
