### PR TITLE
Specific Test Typo Rectified

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ contract OptimizedDistribute {
 
 All tests can be run with: `npx hardhat test`
 
-Specific tests can be run with: `npx hardhat test test/arraySum`
+Specific tests can be run with: `npx hardhat test test/ArraySum`


### PR DESCRIPTION
If we run a specific test with `npx hardhat test test/arraySum`, it will give the error:

```
Error: Cannot find module '/workspaces/gas-puzzles/test/arraySum'
```

It has to be `ArraySum` instead of `arraySum`.