### PR TITLE
🐛 update balance assertion

### DIFF
--- a/test/Security101.js
+++ b/test/Security101.js
@@ -52,7 +52,7 @@ describe('Security101', async function () {
         expect(
             await ethers.provider.getBalance(attacker.address)
         ).to.be.greaterThan(
-            ethers.utils.parseEther('9900'),
+            ethers.utils.parseEther('19900'),
             'attacker gets money'
         );
         expect(


### PR DESCRIPTION
Updated the balance assertion in the test.

Previously, it was checking that attacker's balance must be higher than `9900 ether`, which always pass since the initial balance was `10000`. 

Now, it checks for a balance `greater than 19900 (initial balance 10000 + 9900 from hacking)`